### PR TITLE
DEP: pin numpy >= 1.21

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - xarray >=0.17
     - pyproj >=2.2
     - packaging
+    - numpy >=1.21
 test:
   imports:
     - rioxarray


### PR DESCRIPTION
If you have a tip on how to test running this through `conda install` before it goes to conda-forge, please advise.